### PR TITLE
Session state changed return authgear instance

### DIFF
--- a/javasample/src/main/java/com/oursky/authgeartest/MainViewModel.java
+++ b/javasample/src/main/java/com/oursky/authgeartest/MainViewModel.java
@@ -45,8 +45,8 @@ public class MainViewModel extends AndroidViewModel {
         MainApplication app = getApplication();
         mAuthgear = app.getAuthgear();
         mIsLoggedIn = new MutableLiveData<>(mAuthgear.getSessionState() == SessionState.LoggedIn);
-        mAuthgear.addOnSessionStateChangedListener((state, reason) -> {
-            Log.d(TAG, "Session state=" + state + " reason=" + reason);
+        mAuthgear.addOnSessionStateChangedListener((authgear, reason) -> {
+            Log.d(TAG, "Session state=" + authgear.getSessionState() + " reason=" + reason);
             updateSessionState();
         });
         app.isConfigured().observeForever(mIsConfiguredObserver);

--- a/sdk/src/androidTest/java/com/oursky/authgear/AuthgearTest.kt
+++ b/sdk/src/androidTest/java/com/oursky/authgear/AuthgearTest.kt
@@ -64,13 +64,20 @@ class AuthgearTest {
 
     private lateinit var oauthMock: OauthRepoMock
     private lateinit var authgearCore: AuthgearCore
+    private lateinit var authgearNotUsed: Authgear
 
     @Before
     fun setup() {
         val application =
             InstrumentationRegistry.getInstrumentation().context.applicationContext as Application
         oauthMock = OauthRepoMock()
+        authgearNotUsed = Authgear(
+            application,
+            ClientId,
+            "EndpointNotUsed"
+        )
         authgearCore = AuthgearCore(
+            authgearNotUsed,
             application,
             ClientId,
             "EndpointNotUsed",

--- a/sdk/src/main/java/com/oursky/authgear/Authgear.kt
+++ b/sdk/src/main/java/com/oursky/authgear/Authgear.kt
@@ -36,6 +36,7 @@ constructor(
 
     internal val core =
         AuthgearCore(
+            this,
             application,
             clientId,
             authgearEndpoint,

--- a/sdk/src/main/java/com/oursky/authgear/AuthgearCore.kt
+++ b/sdk/src/main/java/com/oursky/authgear/AuthgearCore.kt
@@ -40,6 +40,7 @@ import kotlin.coroutines.suspendCoroutine
  * Listeners should only be set on the main thread.
  */
 internal class AuthgearCore(
+    private val authgear: Authgear,
     private val application: Application,
     val clientId: String,
     private val authgearEndpoint: String,
@@ -286,7 +287,7 @@ internal class AuthgearCore(
         sessionState = state
         onSessionStateChangedListeners.forEach {
             it.handler.post {
-                it.listener.onSessionStateChanged(state, reason)
+                it.listener.onSessionStateChanged(authgear, reason)
             }
         }
     }

--- a/sdk/src/main/java/com/oursky/authgear/OnSessionStateChangedListener.kt
+++ b/sdk/src/main/java/com/oursky/authgear/OnSessionStateChangedListener.kt
@@ -1,5 +1,5 @@
 package com.oursky.authgear
 
 interface OnSessionStateChangedListener {
-    fun onSessionStateChanged(state: SessionState, reason: SessionStateChangeReason)
+    fun onSessionStateChanged(container: Authgear, reason: SessionStateChangeReason)
 }


### PR DESCRIPTION
fix #29 

return authgear instance in onSessionStateChanged callback, haven't found a good way to achieve this without passing the Authgear instance to AuthgearCore