### PR TITLE
Align behaviour of configure with other SDK

### DIFF
--- a/sdk/src/main/java/com/oursky/authgear/AuthgearCore.kt
+++ b/sdk/src/main/java/com/oursky/authgear/AuthgearCore.kt
@@ -167,8 +167,6 @@ internal class AuthgearCore(
 
     @Suppress("RedundantSuspendModifier")
     suspend fun configure(skipRefreshAccessToken: Boolean = false) {
-        // TODO: This is not present in js sdk. Verify if this is needed.
-        if (isInitialized) return
         isInitialized = true
         val refreshToken = tokenRepo.getRefreshToken(name)
         this.refreshToken = refreshToken


### PR DESCRIPTION
Remove guard for configure such that configure for second time get refresh token and call
onSessionStateChange