### PR TITLE
Add lifecycle extension to sdk dependencies

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     implementation "androidx.security:security-crypto:1.1.0-alpha02"
     implementation "androidx.browser:browser:1.2.0"
     implementation "androidx.appcompat:appcompat:1.2.0"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0"
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.10'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'


### PR DESCRIPTION
Fix cannot access 'androidx.lifecycle.HasDefaultViewModelProviderFactory' warning

<img width="1292" alt="Screenshot 2020-11-05 at 1 13 11 PM" src="https://user-images.githubusercontent.com/54486231/98201149-fc4f1380-1f69-11eb-8caa-6bdc8a940346.png">
