### PR TITLE
Update SDK AuthenticateOption properties in doc

### DIFF
--- a/sdk/src/main/java/com/oursky/authgear/AuthenticateOptions.kt
+++ b/sdk/src/main/java/com/oursky/authgear/AuthenticateOptions.kt
@@ -15,7 +15,7 @@ data class AuthenticateOptions @JvmOverloads constructor(
      */
     var state: String? = null,
     /**
-     * Custom state.
+     * Use this parameter to provide parameters from the client application to Custom UI. The string in xState can be accessed by the Custom UI. Ignore this parameter if default AuthUI is used
      */
     var xState: String? = null,
     /**

--- a/sdk/src/main/java/com/oursky/authgear/AuthenticateOptions.kt
+++ b/sdk/src/main/java/com/oursky/authgear/AuthenticateOptions.kt
@@ -11,17 +11,9 @@ data class AuthenticateOptions @JvmOverloads constructor(
      */
     var redirectUri: String,
     /**
-     * OAuth 2.0 state value.
-     */
-    var state: String? = null,
-    /**
      * Use this parameter to provide parameters from the client application to Custom UI. The string in xState can be accessed by the Custom UI. Ignore this parameter if default AuthUI is used
      */
     var xState: String? = null,
-    /**
-     * OIDC response type parameter.
-     */
-    var responseType: String? = "code",
     /**
      * OIDC prompt parameter.
      *
@@ -34,10 +26,6 @@ data class AuthenticateOptions @JvmOverloads constructor(
      * e.g. Azure Active Directory.
      */
     var prompt: List<PromptOption>? = null,
-    /**
-     * OIDC login hint parameter
-     */
-    var loginHint: String? = null,
     /**
      * UI locale tags
      */
@@ -84,10 +72,10 @@ internal fun AuthenticateOptions.toRequest(
         responseType = "code",
         scope = AuthenticateOptions.getScopes(preAuthenticatedURLEnabled),
         isSsoEnabled = isSsoEnabled,
-        state = this.state,
+        state = null,
         xState = this.xState,
         prompt = this.prompt,
-        loginHint = this.loginHint,
+        loginHint = null,
         idTokenHint = null,
         maxAge = null,
         uiLocales = this.uiLocales,

--- a/sdk/src/main/java/com/oursky/authgear/AuthgearCore.kt
+++ b/sdk/src/main/java/com/oursky/authgear/AuthgearCore.kt
@@ -561,7 +561,7 @@ internal class AuthgearCore(
                 isSsoEnabled = this.isSsoEnabled,
                 prompt = listOf(PromptOption.LOGIN),
                 loginHint = loginHint,
-                state = options.state,
+                state = null,
                 xState = options.xState,
                 uiLocales = options.uiLocales,
                 colorScheme = options.colorScheme,

--- a/sdk/src/main/java/com/oursky/authgear/PromoteOptions.kt
+++ b/sdk/src/main/java/com/oursky/authgear/PromoteOptions.kt
@@ -6,10 +6,6 @@ data class PromoteOptions @JvmOverloads constructor(
      */
     var redirectUri: String,
     /**
-     * OAuth 2.0 state value.
-     */
-    var state: String? = null,
-    /**
      * Use this parameter to provide parameters from the client application to Custom UI. The string in xState can be accessed by the Custom UI. Ignore this parameter if default AuthUI is used
      */
     var xState: String? = null,

--- a/sdk/src/main/java/com/oursky/authgear/PromoteOptions.kt
+++ b/sdk/src/main/java/com/oursky/authgear/PromoteOptions.kt
@@ -10,7 +10,7 @@ data class PromoteOptions @JvmOverloads constructor(
      */
     var state: String? = null,
     /**
-     * Custom state.
+     * Use this parameter to provide parameters from the client application to Custom UI. The string in xState can be accessed by the Custom UI. Ignore this parameter if default AuthUI is used
      */
     var xState: String? = null,
     /**

--- a/sdk/src/main/java/com/oursky/authgear/ReauthenticateOptions.kt
+++ b/sdk/src/main/java/com/oursky/authgear/ReauthenticateOptions.kt
@@ -11,10 +11,6 @@ data class ReauthenticateOptions @JvmOverloads constructor(
      */
     var redirectUri: String,
     /**
-     * OAuth 2.0 state value.
-     */
-    var state: String? = null,
-    /**
      * Use this parameter to provide parameters from the client application to Custom UI. The string in xState can be accessed by the Custom UI. Ignore this parameter if default AuthUI is used
      */
     var xState: String? = null,
@@ -54,7 +50,7 @@ internal fun ReauthenticateOptions.toRequest(idTokenHint: String, isSsoEnabled: 
         // because no new session should be generated so the scopes are not important.
         scope = listOf("openid", "https://authgear.com/scopes/full-access"),
         isSsoEnabled = isSsoEnabled,
-        state = this.state,
+        state = null,
         xState = this.xState,
         prompt = null,
         loginHint = null,

--- a/sdk/src/main/java/com/oursky/authgear/ReauthenticateOptions.kt
+++ b/sdk/src/main/java/com/oursky/authgear/ReauthenticateOptions.kt
@@ -15,7 +15,7 @@ data class ReauthenticateOptions @JvmOverloads constructor(
      */
     var state: String? = null,
     /**
-     * Custom state.
+     * Use this parameter to provide parameters from the client application to Custom UI. The string in xState can be accessed by the Custom UI. Ignore this parameter if default AuthUI is used
      */
     var xState: String? = null,
     /**


### PR DESCRIPTION
@louischan-oursky searched in the project seems the SDK only uses `redirectUri` in `AuthenticateOption`. so just removed properties that need to be hidden from requirement. see if there is any problem

Preview:

<img width="710" alt="Screenshot 2024-09-04 at 5 44 00 PM" src="https://github.com/user-attachments/assets/1fc84e45-8d7c-4c41-bd63-5fcdcd580220">
<img width="1213" alt="Screenshot 2024-09-04 at 5 43 54 PM" src="https://github.com/user-attachments/assets/91c4bc1f-4293-4da8-9e26-61fb51878e5b">